### PR TITLE
Record 4K and 2K at the screen's shape

### DIFF
--- a/app/src/main/java/com/zygisk_enc/RecorderX/RecordingSession.java
+++ b/app/src/main/java/com/zygisk_enc/RecorderX/RecordingSession.java
@@ -237,6 +237,10 @@ public class RecordingSession {
 
     private boolean tryConfigureVideoEncoder(String mime, int width, int height, int fps, int bitrate, int bitrateMode, boolean useHighProfile, boolean requireHardware) {
         try {
+            int[] fitted = fitToEncoder(mime, width, height);
+            width = fitted[0];
+            height = fitted[1];
+
             MediaFormat format = MediaFormat.createVideoFormat(mime, width, height);
             format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
             format.setInteger(MediaFormat.KEY_BIT_RATE, bitrate);
@@ -254,8 +258,7 @@ public class RecordingSession {
 
             videoEncoder = MediaCodec.createEncoderByType(mime);
 
-            // A CPU encoder cannot sustain screen capture. AV1 has no hardware encoder on most
-            // devices, so createEncoderByType silently hands back libaom and the capture crawls
+            // Most devices have no hardware AV1 encoder, so createEncoderByType hands back libaom
             if (requireHardware && !videoEncoder.getCodecInfo().isHardwareAccelerated()) {
                 Log.w(TAG, "Rejecting software encoder " + videoEncoder.getCodecInfo().getName() + " for " + mime);
                 throw new IllegalStateException("no hardware encoder for " + mime);
@@ -311,6 +314,53 @@ public class RecordingSession {
                 android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show());
     }
 
+    // A preset that follows a tall screen can outrun the encoder, so fit into its range and keep the shape
+    private int[] fitToEncoder(String mime, int width, int height) {
+        MediaCodecInfo.VideoCapabilities caps = videoCapabilitiesFor(mime);
+        if (caps == null) return new int[]{width, height};
+
+        width = alignDown(width, caps.getWidthAlignment());
+        height = alignDown(height, caps.getHeightAlignment());
+        if (caps.isSizeSupported(width, height)) return new int[]{width, height};
+
+        float k = Math.min((float) caps.getSupportedWidths().getUpper() / width,
+                (float) caps.getSupportedHeights().getUpper() / height);
+        if (k >= 1f) return new int[]{width, height};
+
+        int fittedWidth = alignDown((int) (width * k), Math.max(2, caps.getWidthAlignment()));
+        int fittedHeight = alignDown((int) (height * k), Math.max(2, caps.getHeightAlignment()));
+        if (!caps.isSizeSupported(fittedWidth, fittedHeight)) return new int[]{width, height};
+
+        Log.i(TAG, "Encoder tops out below " + width + "x" + height
+                + ", fitting to " + fittedWidth + "x" + fittedHeight);
+        return new int[]{fittedWidth, fittedHeight};
+    }
+
+    private MediaCodecInfo.VideoCapabilities videoCapabilitiesFor(String mime) {
+        android.media.MediaCodecList list = new android.media.MediaCodecList(android.media.MediaCodecList.REGULAR_CODECS);
+        for (MediaCodecInfo info : list.getCodecInfos()) {
+            if (!info.isEncoder()) continue;
+            for (String type : info.getSupportedTypes()) {
+                if (!type.equalsIgnoreCase(mime)) continue;
+                MediaCodecInfo.CodecCapabilities caps = info.getCapabilitiesForType(mime);
+                return caps != null ? caps.getVideoCapabilities() : null;
+            }
+        }
+        return null;
+    }
+
+    private int alignDown(int value, int alignment) {
+        return alignment <= 1 ? value : (value / alignment) * alignment;
+    }
+
+    // Fallback rungs have to keep the screen's shape too, or a rejection reintroduces the bars
+    private int[] scaleToShortEdge(int width, int height, int shortEdge) {
+        int shortSide = Math.min(width, height);
+        if (shortSide <= shortEdge) return new int[]{width & ~1, height & ~1};
+        float k = (float) shortEdge / shortSide;
+        return new int[]{((int) (width * k)) & ~1, ((int) (height * k)) & ~1};
+    }
+
     // A flat bitrate starves high-resolution captures, so scale a floor from pixels per second
     private int minimumBitrate(int width, int height, int fps, String mime) {
         double bitsPerPixel = MediaFormat.MIMETYPE_VIDEO_AVC.equals(mime) ? 0.10 : 0.07;
@@ -344,13 +394,11 @@ public class RecordingSession {
                 return;
             }
 
-            boolean isLandscape = originalWidth > originalHeight;
-
-            // Dimensions for 1080p and 720p
-            int w1080 = isLandscape ? 1920 : 1080;
-            int h1080 = isLandscape ? 1080 : 1920;
-            int w720 = isLandscape ? 1280 : 720;
-            int h720 = isLandscape ? 720 : 1280;
+            // Dimensions for 1080p and 720p, kept in the screen's shape
+            int[] r1080 = scaleToShortEdge(originalWidth, originalHeight, 1080);
+            int[] r720 = scaleToShortEdge(originalWidth, originalHeight, 720);
+            int w1080 = r1080[0], h1080 = r1080[1];
+            int w720 = r720[0], h720 = r720[1];
 
             // Step 2: 1080p @ Max 60 FPS (12 Mbps)
             if (tryConfigureVideoEncoder(mime, w1080, h1080, Math.min(originalFps, 60), 12000000, mode, false, true)) {
@@ -374,8 +422,8 @@ public class RecordingSession {
         }
 
         // Rock Bottom (720p 30fps safe fallback with safeMime)
-        int safeWidth = originalWidth > originalHeight ? 1280 : 720;
-        int safeHeight = originalWidth > originalHeight ? 720 : 1280;
+        int[] safe = scaleToShortEdge(originalWidth, originalHeight, 720);
+        int safeWidth = safe[0], safeHeight = safe[1];
         // Last resort only: accept a software encoder rather than fail to record at all
         if (tryConfigureVideoEncoder(safeMime, safeWidth, safeHeight, 30, 4000000, originalBitrateMode, false, false)) {
             return;

--- a/app/src/main/java/com/zygisk_enc/RecorderX/SettingsManager.java
+++ b/app/src/main/java/com/zygisk_enc/RecorderX/SettingsManager.java
@@ -68,53 +68,46 @@ public class SettingsManager {
     }
 
     public int getResolutionWidth() {
-        DisplayMetrics dm = getMetrics();
-        int orientPref = getOrientation();
-        boolean isLandscape;
-        if (orientPref == 1) isLandscape = false;
-        else if (orientPref == 2) isLandscape = true;
-        else isLandscape = context.getResources().getConfiguration().orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
-        
-        int shortSide = Math.min(dm.widthPixels, dm.heightPixels);
-        int longSide = Math.max(dm.widthPixels, dm.heightPixels);
-        
-        int width;
-        switch (getResolution()) {
-            case 1: width = isLandscape ? 3840 : 2160; break; // 4K
-            case 2: width = isLandscape ? 2560 : 1440; break; // 2K
-            case 3: width = isLandscape ? 1920 : 1080; break; // 1080p
-            case 4: width = isLandscape ? 1280 : 720; break;  // 720p
-            case 5: width = isLandscape ? 854 : 480; break;   // 480p
-            default: width = isLandscape ? longSide : shortSide; break;
-        }
-        return makeMultipleOf16(width);
+        return isLandscapeCapture() ? makeEven(longEdge()) : makeEven(shortEdge());
     }
 
     public int getResolutionHeight() {
-        DisplayMetrics dm = getMetrics();
-        int orientPref = getOrientation();
-        boolean isLandscape;
-        if (orientPref == 1) isLandscape = false;
-        else if (orientPref == 2) isLandscape = true;
-        else isLandscape = context.getResources().getConfiguration().orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
-
-        int shortSide = Math.min(dm.widthPixels, dm.heightPixels);
-        int longSide = Math.max(dm.widthPixels, dm.heightPixels);
-
-        int height;
-        switch (getResolution()) {
-            case 1: height = isLandscape ? 2160 : 3840; break; // 4K
-            case 2: height = isLandscape ? 1440 : 2560; break; // 2K
-            case 3: height = isLandscape ? 1080 : 1920; break; // 1080p
-            case 4: height = isLandscape ? 720 : 1280; break;  // 720p
-            case 5: height = isLandscape ? 480 : 854; break;   // 480p
-            default: height = isLandscape ? shortSide : longSide; break;
-        }
-        return makeMultipleOf16(height);
+        return isLandscapeCapture() ? makeEven(shortEdge()) : makeEven(longEdge());
     }
 
-    private int makeMultipleOf16(int value) {
-        return (value / 16) * 16;
+    private boolean isLandscapeCapture() {
+        int orientPref = getOrientation();
+        if (orientPref == 1) return false;
+        if (orientPref == 2) return true;
+        return context.getResources().getConfiguration().orientation
+                == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
+    }
+
+    // The preset names a short edge only; the long edge follows the screen so nothing is letterboxed
+    private int shortEdge() {
+        switch (getResolution()) {
+            case 1: return 2160;
+            case 2: return 1440;
+            case 3: return 1080;
+            case 4: return 720;
+            case 5: return 480;
+            default: {
+                DisplayMetrics dm = getMetrics();
+                return Math.min(dm.widthPixels, dm.heightPixels);
+            }
+        }
+    }
+
+    private int longEdge() {
+        DisplayMetrics dm = getMetrics();
+        int screenShort = Math.max(1, Math.min(dm.widthPixels, dm.heightPixels));
+        int screenLong = Math.max(dm.widthPixels, dm.heightPixels);
+        return Math.round(shortEdge() * (float) screenLong / screenShort);
+    }
+
+    // Rounding to 16 forced a rescale of the native size; the encoder's own alignment is applied later
+    private int makeEven(int value) {
+        return value & ~1;
     }
 
     private DisplayMetrics getMetrics() {


### PR DESCRIPTION
4K and 2K were fixed 16:9, so on a 19.6:9 phone the mirror fits the screen into a 9:16 frame and leaves black bars down both sides. Presets now name a short edge and the long edge follows the display, giving 2160x4706 and 1440x3138 on a 1272x2772 screen.

Rounding every size down to a multiple of 16 shifted that derived aspect back off, and on the native setting it turned 1272x2772 into 1264x2768 - a 0.9937 rescale that converts into visible lines. Sizes are now even, and the encoder's own alignment is queried and applied instead of assuming 16.

Ask the encoder for its size range before configuring and shrink into it only when it refuses. A tall screen can put the long edge past what the encoder takes, and without this the request drops a rung to 1080p rather than giving a smaller 4K in the same shape.

The fallback rungs follow the screen too, since fixing the presets alone let a rejected request land back on 16:9 and bring the black bars back.