### PR TITLE
Release the encoder's input surface

### DIFF
--- a/app/src/main/java/com/zygisk_enc/RecorderX/RecordingSession.java
+++ b/app/src/main/java/com/zygisk_enc/RecorderX/RecordingSession.java
@@ -705,6 +705,7 @@ public class RecordingSession {
         }
 
         try { if (videoEncoder != null) { videoEncoder.stop(); videoEncoder.release(); } } catch (Exception ignored) {}
+        try { if (inputSurface != null) { inputSurface.release(); inputSurface = null; } } catch (Exception ignored) {}
         try { if (audioEncoder != null) { audioEncoder.stop(); audioEncoder.release(); } } catch (Exception ignored) {}
         try { if (audioRecord != null) { audioRecord.stop(); audioRecord.release(); } } catch (Exception ignored) {}
         try { if (audioRecordSecondary != null) { audioRecordSecondary.stop(); audioRecordSecondary.release(); } } catch (Exception ignored) {}


### PR DESCRIPTION
createInputSurface() hands back a Surface backed by a native buffer queue, and stop() released the encoder, the audio encoder and both AudioRecords but never the surface. It leaked per recording for the life of the process.
release the surface with inputSurface.release()
